### PR TITLE
Filter broken items to un-break the audio feed

### DIFF
--- a/src/qcast/feed/feed.clj
+++ b/src/qcast/feed/feed.clj
@@ -12,24 +12,25 @@
   ([n] (cons (str "Slide " n) (lazy-seq (slides (inc n))))))
 
 (defn- feed-item [media-type p]
-  (let [link (:link p)]
+(let [link (:link p)]
     (remove nil?
-      [(rss/title (:title p))
-       (rss/link link)
-       (rss/description (:summary p))
-       ;;(rss/author (string/join ", " (:authors p)))
-       (rss/author "info@infoq.com (InfoQ)")
-       (rss/pub-date (:publish-date p))
-       (rss/guid link)
-       (when (contains? p media-type) (apply rss/enclosure (media-type p)))
-       (apply rss/categories (:keywords p))
-       ;;(itunes/author (string/join ", " (:authors p)))
-       (itunes/author "info@infoq.com")
-       (itunes/summary (:summary p))
-       ;;(itunes/image (:poster p))
-       (itunes/image (first (:slides p)))
-       (itunes/duration (:length p))
-       (apply psc/chapters (map vector (:times p) (slides) (:slides p)))])))
+      (when-not (nil? (media-type p))
+        [(rss/title (:title p))
+         (rss/link link)
+         (rss/description (:summary p))
+         ;;(rss/author (string/join ", " (:authors p)))
+         (rss/author "info@infoq.com (InfoQ)")
+         (rss/pub-date (:publish-date p))
+         (rss/guid link)
+         (when (contains? p media-type) (apply rss/enclosure (media-type p)))
+         (apply rss/categories (:keywords p))
+         ;;(itunes/author (string/join ", " (:authors p)))
+         (itunes/author "info@infoq.com")
+         (itunes/summary (:summary p))
+         ;;(itunes/image (:poster p))
+         (itunes/image (first (:slides p)))
+         (itunes/duration (:length p))
+         (apply psc/chapters (map vector (:times p) (slides) (:slides p)))]))))
 
 (defn- feed-channel [change-date]
   (let [base-url "https://www.infoq.com"

--- a/src/qcast/feed/rss.clj
+++ b/src/qcast/feed/rss.clj
@@ -70,7 +70,7 @@
     (assert (and link title description)
             "RSS channel requires at least :link, :title, and :description")
     (let [channel (insert? info [:generator feed-generator])
-          items (map item entries)]
+          items (map item (remove empty? entries))]
       [:channel (concat channel items)])))
 
 


### PR DESCRIPTION
The audio (but not video) RSS feed has been broken for a few days. Looks like some bad data was getting in. Would be better to filter it out (or clean it) at the time of scraping, but in lieu of that, this seems to work -- so that building the feeds can happen.
